### PR TITLE
Remove version constraints from all dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -17,7 +17,7 @@
 
 - 🧪 **Testing** - Pytest with 80%+ coverage requirement
 - 🔧 **Code Quality** - Ruff for linting and formatting
-- 📦 **Dependency Management** - UV for fast package management
+- 📦 **Dependency Management** - UV for fast package management (always installs latest versions, with reproducible builds via uv.lock)
 - 🏗️ **Task Runner** - Just for common development tasks
 - 🪝 **Pre-commit Hooks** - Automated code quality checks
 - 📚 **Documentation** - MkDocs with Material theme
@@ -44,8 +44,11 @@ just dev-setup
 This will:
 
 - Create a virtual environment
-- Install all dependencies
+- Install all dependencies (latest versions)
+- Generate a `uv.lock` file for reproducible builds
 - Set up pre-commit hooks
+
+> **Note**: This project is configured to always install the latest versions of all dependencies. The `uv.lock` file ensures reproducible builds across environments while still allowing you to stay current with the latest package releases.
 
 ## Development
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -17,47 +17,47 @@ classifiers = [
 ]
 
 dependencies = [
-    "pydantic>=2.0",
-    "requests>=2.32",
-    "python-dotenv>=1.0",
-    "tqdm>=4.66",
+    "pydantic",
+    "requests",
+    "python-dotenv",
+    "tqdm",
     {% if cookiecutter.project_type in ['full', 'data_science'] or cookiecutter.include_data_science == 'y' -%}
-    "pandas>=2.2",
+    "pandas",
     {% endif -%}
 ]
 
 [project.optional-dependencies]
 {% if cookiecutter.include_fastapi == 'y' -%}
 api = [
-    "fastapi>=0.111",
-    "uvicorn[standard]>=0.29",
+    "fastapi",
+    "uvicorn[standard]",
 ]
 {% endif -%}
 {% if cookiecutter.include_typer == 'y' -%}
 cli = [
-    "typer>=0.12",
-    "rich>=13.0",
+    "typer",
+    "rich",
 ]
 {% endif -%}
 {% if cookiecutter.include_data_science == 'y' -%}
 ds = [
-    "matplotlib>=3.8",
-    "seaborn>=0.13",
-    "polars>=0.20",
-    "scikit-learn>=1.3",
-    "numpy>=1.24",
+    "matplotlib",
+    "seaborn",
+    "polars",
+    "scikit-learn",
+    "numpy",
 ]
 {% endif -%}
 
 dev = [
-    "pytest>=8.0",
-    "pytest-cov>=5.0",
-    "ruff>=0.4",
-    "deptry>=0.12",
-    "mkdocs>=1.5",
-    "mkdocs-material>=9.5",
-    "mkdocstrings[python]>=0.24",
-    "pre-commit>=3.6",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "deptry",
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocstrings[python]",
+    "pre-commit",
 ]
 
 {% if cookiecutter.include_typer == 'y' -%}
@@ -66,7 +66,7 @@ dev = [
 {% endif %}
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR removes version-specific constraints from dependencies in the cookiecutter template to allow for more flexible dependency management and reduce maintenance overhead.